### PR TITLE
HOCS-1990: use latest aliase for mapping with elastic search

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -171,7 +171,7 @@ spec:
                   name: ui-casework-creds
                   key: plaintext
             - name: ELASTIC_INDEX_PREFIX
-              value: {{.KUBE_NAMESPACE}}
+              value: {{.KUBE_NAMESPACE}}-latest
             - name: SEARCH_QUEUE_NAME
               value: {{.KUBE_NAMESPACE}}-search-sqs
             - name: SEARCH_QUEUE_DLQ_NAME


### PR DESCRIPTION
As a result of having to remap the AWS elastic search index, we are starting to use aliases to remove the need to update this file on every deployment. The aliases will follow the (ENV)-latest format. This internally then points to the correct index.