### PR TITLE
HOCS-2094 Use minAvailable over maxUnavailable

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       name: hocs-search
   strategy:
     rollingUpdate:
-      maxUnavailable: 0
+      minAvailable: 1
       maxSurge: 2
     type: RollingUpdate
   template:


### PR DESCRIPTION
Prior to this commit we were using `maxUnavailable` to govern the number
of pods that are allowed to be not working at any given time. A value of
`maxUnavailable: 0` means that we are requiring 0 voluntary evictions.

This meant that some of our pods were getting killed without a
replacement being immediately available, meaning that we had some 503
errors during switchover.

This commit changes `maxUnavailable` to the more tenable `minAvailable`,
which I think was the intended behaviour to start with: ensure there's
always at least 1 pod running and ready at all times.